### PR TITLE
distinguish between warning and error colors

### DIFF
--- a/themes/halcyon-color-theme.json
+++ b/themes/halcyon-color-theme.json
@@ -189,7 +189,7 @@
     // Errors and warnings
     "editorError.foreground": "#ef6b73",
     // "editorError.border": "#ef6b73",
-    "editorWarning.foreground": "#ef6b73",
+    "editorWarning.foreground": "#ffd580",
     // "editorWarning.border": "#ef6b73",
     "editorInfo.foreground": "#5ccfe6",
     // "editorInfo.border": "#5ccfe6",


### PR DESCRIPTION
Thank you for this wonderful theme!  The current version of the theme doesn't distinguish between warnings and errors -- in both cases the squiggle is red.  This PR changes the warning color to one of the yellows used by the theme.

Before:
<img width="438" alt="Screen Shot 2020-04-16 at 09 55 24" src="https://user-images.githubusercontent.com/1042048/79429877-6735fe80-7fc8-11ea-8b4e-de80e7269fe5.png">

After:
<img width="459" alt="Screen Shot 2020-04-16 at 09 53 12" src="https://user-images.githubusercontent.com/1042048/79429660-1aeabe80-7fc8-11ea-8b1e-f479a83593a6.png">
