### PR TITLE
too much bluee

### DIFF
--- a/themes/halcyon-color-theme.json
+++ b/themes/halcyon-color-theme.json
@@ -8,11 +8,13 @@
       "italic": false
     },
     "variable": "#5ccfe6",
+    "variable.declaration": "#a2aabc",
     "parameter": "#5ccfe6",
     "interface": "#ffd580",
     "type": "#ffd580",
     "property": "#5ccfe6",
-    "property.readonly": "#a2aabc"
+    "property.readonly": "#a2aabc",
+    "selfParameter": "#ffd580",
   },
   "colors": {
     // Base colors


### PR DESCRIPTION
small fix:

semantic highlighting gets confused inside highly nested class, when referencing an obj that is both a "variable" and "parameter". two small asks:

1) change initial declaration of variable to be off-gray (#a2aabc)
2) change `selfParameter` to be yellow (#ffd580)

### BEFORE
<img width="615" alt="image" src="https://github.com/bchiang7/halcyon-vscode/assets/70116345/816ea316-fc5c-4c29-aaf7-533ce91cadd6">

### AFTER
<img width="615" alt="image" src="https://github.com/bchiang7/halcyon-vscode/assets/70116345/cb772344-f784-4848-ae58-a52d18206479">

I tried this out on python and ts, and it looks fine. but let me know if it works for your case. 

also, if you don't want to have too many semanticTokenColors i understand :)