### PR TITLE
Use rule 'Class, Support' for support.type

### DIFF
--- a/themes/halcyon-color-theme.json
+++ b/themes/halcyon-color-theme.json
@@ -590,7 +590,6 @@
     {
       "name": "Entity Types",
       "scope": [
-        "support.type",
         "support.class",
         "keyword.other.debugger",
         "entity.other.inherited-class",


### PR DESCRIPTION
`support.type` was overruled by rule 'Entity Types'. This is now changed.

Before:

![Scherm­afbeelding 2024-08-30 om 10 41 55](https://github.com/user-attachments/assets/83f15ccc-575c-40d5-b9c0-b592b891cbd1)

After: 

![Scherm­afbeelding 2024-08-30 om 10 41 42](https://github.com/user-attachments/assets/bb7de299-6ee5-4ebc-8cc9-156e9452e041)
