### PR TITLE
Fix outdated links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   Halcyon Theme for VS Code
 </h1>
 <p align="center">
-  A minimal, dark blue theme for <a href="https://halcyon-theme.netlify.com/">VS Code, Sublime Text, Atom, and more</a>.
+  A minimal, dark blue theme for <a href="https://halcyon-theme.netlify.app/">VS Code, Sublime Text, Atom, and more</a>.
 </p>
 <p align="center">
   <a href="https://marketplace.visualstudio.com/items?itemName=brittanychiang.halcyon-vscode">
@@ -19,7 +19,7 @@
   </a>
 </p>
 
-![demo](https://raw.githubusercontent.com/bchiang7/halcyon-vscode/master/images/demo.png)
+![demo](https://raw.githubusercontent.com/bchiang7/halcyon-vscode/main/images/demo.png)
 
 ## Installation via VS Code
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img alt="Halcyon Logo" src="https://raw.githubusercontent.com/bchiang7/halcyon-vscode/master/images/logo.png" width="100" />
+  <img alt="Halcyon Logo" src="https://raw.githubusercontent.com/bchiang7/halcyon-vscode/main/images/logo.png" width="100" />
 </p>
 <h1 align="center">
   Halcyon Theme for VS Code
@@ -31,7 +31,7 @@
 
 ## Manual Installation
 
-Read the [VSC Extension Quickstart Guide](https://github.com/bchiang7/halcyon-vscode/blob/master/vsc-extension-quickstart.md)
+Read the [VSC Extension Quickstart Guide](https://github.com/bchiang7/halcyon-vscode/blob/main/vsc-extension-quickstart.md)
 
 ## Icon Theme
 


### PR DESCRIPTION
Fixed some links for ya :) Been using this theme for years! Thanks for continuing to maintain it.

### Link to netlify site:
Before | After
:---: | :---:
https://halcyon-theme.netlify.com/ | https://halcyon-theme.netlify.app/
<img width="1128" height="926" alt="image" src="https://github.com/user-attachments/assets/7f8f446e-d9fd-4748-84fe-0807b10913d5" /> | <img width="1115" height="929" alt="image" src="https://github.com/user-attachments/assets/c69bdeb4-d7f0-47af-8bfb-5673d0542d46" />

### Updated "master" links to "main"
- The images didn't seem to have an issue, but GitHub wasn't properly redirecting the Extension Guide URL 100% of the time for me for some reason. I thought I'd just fix all three of them.

Before | After
:---: | :---:
https://github.com/bchiang7/halcyon-vscode/blob/master/vsc-extension-quickstart.md | https://github.com/bchiang7/halcyon-vscode/blob/main/vsc-extension-quickstart.md
<img width="1918" height="927" alt="image" src="https://github.com/user-attachments/assets/c6cb8290-be21-47c3-9e0c-01c8bcd42505" /> | <img width="1919" height="927" alt="image" src="https://github.com/user-attachments/assets/03a7021e-87a6-4782-b3b8-03f2b3a0a040" />